### PR TITLE
Fix peerlist

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -501,7 +501,7 @@ namespace nodetool
         if (result.size())
         {
           for (const auto& addr_string : result)
-            full_addrs.insert(addr_string + ":3000");
+            full_addrs.insert(addr_string + ":30000");
         }
         ++i;
       }


### PR DESCRIPTION
#25 Simply net node issue where the peers may have searched the wrong port. Since #25 and all future releases it's been properly fixed. 